### PR TITLE
fix: json loader for pre-merge forks

### DIFF
--- a/GNOSIS.md
+++ b/GNOSIS.md
@@ -62,9 +62,11 @@ Implementation: `packages/testing/src/execution_testing/test_types/block_types.p
 |---|---|---|---|---|
 | `just fill` | `ConstantinopleFix` | `Osaka` (latest) | AuRa (pre-merge), standard (post-merge) | Gnosis Hive client tests |
 | `just fill-pypy` | `ConstantinopleFix` | `Osaka` (latest) | AuRa (pre-merge), standard (post-merge) | PyPy fill verification |
-| `just json-loader` | `Paris` | `Osaka` (latest) | Standard only | EELS Python spec validation |
+| `just json-loader` | `ConstantinopleFix` | `Osaka` (latest) | AuRa (pre-merge), standard (post-merge) | EELS Python spec validation |
 
-Pre-merge forks are excluded from `json-loader` because EELS validates headers using standard Ethereum rules (8-byte `Bytes8` nonce, PoW difficulty check) which are incompatible with AuRa headers.
+The JSON loader recognizes the active pre-merge forks as AuRa, decodes their
+variable-length step and seal fields, and validates the fixed AuRa difficulty
+instead of Ethereum PoW.
 
 The `just fill` recipe (and `fill-pypy`) starts from `ConstantinopleFix` because:
 

--- a/src/ethereum/forks/berlin/blocks.py
+++ b/src/ethereum/forks/berlin/blocks.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Tuple, final
 
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes, Bytes8, Bytes32
+from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
@@ -142,7 +142,7 @@ class Header:
     Arbitrary data included by the miner.
     """
 
-    mix_digest: Bytes32
+    mix_digest: Bytes
     """
     Mix hash used in the mining process, which is a cryptographic commitment
     to the block's contents. It [validates][u] that PoW was done on the correct
@@ -151,7 +151,7 @@ class Header:
     [u]: ref:ethereum.forks.berlin.fork.validate_proof_of_work
     """
 
-    nonce: Bytes8
+    nonce: Bytes
     """
     Nonce used in the mining process, which is a value that miners
     increment to find a valid block hash. This is also used to [validate][v]

--- a/src/ethereum/forks/berlin/fork.py
+++ b/src/ethereum/forks/berlin/fork.py
@@ -16,7 +16,7 @@ from typing import List, Optional, Set, Tuple, final
 
 from eth_abi import decode
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes8
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
@@ -365,7 +365,10 @@ def validate_proof_of_work(header: Header) -> None:
     # calculating cache for every block validation.
     cache = generate_cache(header.number)
     mix_digest, result = hashimoto_light(
-        header_hash, header.nonce, cache, dataset_size(header.number)
+        header_hash,
+        Bytes8(header.nonce),
+        cache,
+        dataset_size(header.number),
     )
     if mix_digest != header.mix_digest:
         raise InvalidBlock

--- a/src/ethereum/forks/constantinople/blocks.py
+++ b/src/ethereum/forks/constantinople/blocks.py
@@ -12,7 +12,7 @@ chain.
 from dataclasses import dataclass
 from typing import Tuple, final
 
-from ethereum_types.bytes import Bytes, Bytes8, Bytes32
+from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
@@ -141,7 +141,7 @@ class Header:
     Arbitrary data included by the miner.
     """
 
-    mix_digest: Bytes32
+    mix_digest: Bytes
     """
     Mix hash used in the mining process, which is a cryptographic commitment
     to the block's contents. It [validates][u] that PoW was done on the correct
@@ -150,7 +150,7 @@ class Header:
     [u]: ref:ethereum.forks.constantinople.fork.validate_proof_of_work
     """
 
-    nonce: Bytes8
+    nonce: Bytes
     """
     Nonce used in the mining process, which is a value that miners
     increment to find a valid block hash. This is also used to [validate][v]

--- a/src/ethereum/forks/constantinople/fork.py
+++ b/src/ethereum/forks/constantinople/fork.py
@@ -16,7 +16,7 @@ from typing import List, Optional, Set, Tuple, final
 
 from eth_abi import decode
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes8
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
@@ -361,7 +361,10 @@ def validate_proof_of_work(header: Header) -> None:
     # calculating cache for every block validation.
     cache = generate_cache(header.number)
     mix_digest, result = hashimoto_light(
-        header_hash, header.nonce, cache, dataset_size(header.number)
+        header_hash,
+        Bytes8(header.nonce),
+        cache,
+        dataset_size(header.number),
     )
     if mix_digest != header.mix_digest:
         raise InvalidBlock

--- a/src/ethereum/forks/istanbul/blocks.py
+++ b/src/ethereum/forks/istanbul/blocks.py
@@ -12,7 +12,7 @@ chain.
 from dataclasses import dataclass
 from typing import Tuple, final
 
-from ethereum_types.bytes import Bytes, Bytes8, Bytes32
+from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
@@ -141,7 +141,7 @@ class Header:
     Arbitrary data included by the miner.
     """
 
-    mix_digest: Bytes32
+    mix_digest: Bytes
     """
     Mix hash used in the mining process, which is a cryptographic commitment
     to the block's contents. It [validates][u] that PoW was done on the correct
@@ -150,7 +150,7 @@ class Header:
     [u]: ref:ethereum.forks.istanbul.fork.validate_proof_of_work
     """
 
-    nonce: Bytes8
+    nonce: Bytes
     """
     Nonce used in the mining process, which is a value that miners
     increment to find a valid block hash. This is also used to [validate][v]

--- a/src/ethereum/forks/istanbul/fork.py
+++ b/src/ethereum/forks/istanbul/fork.py
@@ -16,7 +16,7 @@ from typing import List, Optional, Set, Tuple, final
 
 from eth_abi import decode
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes8
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
@@ -361,7 +361,10 @@ def validate_proof_of_work(header: Header) -> None:
     # calculating cache for every block validation.
     cache = generate_cache(header.number)
     mix_digest, result = hashimoto_light(
-        header_hash, header.nonce, cache, dataset_size(header.number)
+        header_hash,
+        Bytes8(header.nonce),
+        cache,
+        dataset_size(header.number),
     )
     if mix_digest != header.mix_digest:
         raise InvalidBlock

--- a/src/ethereum/forks/london/blocks.py
+++ b/src/ethereum/forks/london/blocks.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Tuple, final
 
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes, Bytes8, Bytes32
+from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
@@ -156,7 +156,7 @@ class Header:
     Arbitrary data included by the miner.
     """
 
-    mix_digest: Bytes32
+    mix_digest: Bytes
     """
     Mix hash used in the mining process, which is a cryptographic commitment
     to the block's contents. It [validates][u] that PoW was done on the correct
@@ -165,7 +165,7 @@ class Header:
     [u]: ref:ethereum.forks.london.fork.validate_proof_of_work
     """
 
-    nonce: Bytes8
+    nonce: Bytes
     """
     Nonce used in the mining process, which is a value that miners
     increment to find a valid block hash. This is also used to [validate][v]

--- a/src/ethereum/forks/london/fork.py
+++ b/src/ethereum/forks/london/fork.py
@@ -16,7 +16,7 @@ from typing import List, Optional, Set, Tuple, final
 
 from eth_abi import decode
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes8
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
@@ -455,7 +455,10 @@ def validate_proof_of_work(header: Header) -> None:
     # calculating cache for every block validation.
     cache = generate_cache(header.number)
     mix_digest, result = hashimoto_light(
-        header_hash, header.nonce, cache, dataset_size(header.number)
+        header_hash,
+        Bytes8(header.nonce),
+        cache,
+        dataset_size(header.number),
     )
     if mix_digest != header.mix_digest:
         raise InvalidBlock

--- a/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Tuple
 
 from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256
 
 from ethereum.crypto.hash import Hash32, keccak256
@@ -152,6 +153,18 @@ class Load(BaseLoad):
 
     def json_to_header(self, raw: Any) -> Any:
         """Converts json header data to a header object."""
+        if self.fork.is_aura:
+            number = hex_to_uint(raw.get("number"))
+            mix_digest = Bytes(number.to_be_bytes())
+            nonce = (
+                Bytes(b"\x00" * 65)
+                if number == 0
+                else hex_to_bytes(raw.get("nonce"))
+            )
+        else:
+            mix_digest = hex_to_bytes32(raw.get("mixHash"))
+            nonce = hex_to_bytes8(raw.get("nonce"))
+
         parameters = [
             hex_to_hash(raw.get("parentHash")),
             hex_to_hash(raw.get("uncleHash") or raw.get("sha3Uncles")),
@@ -172,8 +185,8 @@ class Load(BaseLoad):
             hex_to_uint(raw.get("gasUsed")),
             hex_to_u256(raw.get("timestamp")),
             hex_to_bytes(raw.get("extraData")),
-            hex_to_bytes32(raw.get("mixHash")),
-            hex_to_bytes8(raw.get("nonce")),
+            mix_digest,
+            nonce,
         ]
 
         if "baseFeePerGas" in raw:

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -49,6 +49,16 @@ class ForkLoad:
         return self.hardfork.consensus.is_pos()
 
     @property
+    def is_aura(self) -> bool:
+        """Whether the fork uses Gnosis AuRa header encoding."""
+        return self.hardfork.short_name in {
+            "constantinople",
+            "istanbul",
+            "berlin",
+            "london",
+        }
+
+    @property
     def BEACON_ROOTS_ADDRESS(self) -> Any:
         """BEACON_ROOTS_ADDRESS of the given fork."""
         return self._module("fork").BEACON_ROOTS_ADDRESS

--- a/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
@@ -27,6 +27,14 @@ EXCEPTIONAL_DIFFS = [
     # graffiti near the fork block.
     ("dao_fork", ".fork", "apply_fork"),
     ("dao_fork", ".fork", "validate_header"),
+    # Gnosis skips the glacier forks, so its active pre-merge forks use AuRa
+    # header fields while the inactive glacier forks retain Ethereum PoW.
+    ("muir_glacier", ".blocks", "Header.mix_digest"),
+    ("muir_glacier", ".blocks", "Header.nonce"),
+    ("muir_glacier", ".fork", "validate_proof_of_work"),
+    ("arrow_glacier", ".blocks", "Header.mix_digest"),
+    ("arrow_glacier", ".blocks", "Header.nonce"),
+    ("arrow_glacier", ".fork", "validate_proof_of_work"),
     # There are some differences between london and arrow_glacier
     # in terms of how the fork block is handled.
     ("arrow_glacier", ".fork", "calculate_base_fee_per_gas"),

--- a/tests/json_loader/helpers/load_blockchain_tests.py
+++ b/tests/json_loader/helpers/load_blockchain_tests.py
@@ -8,7 +8,7 @@ import pytest
 from _pytest.config import Config
 from ethereum_rlp import rlp
 from ethereum_rlp.exceptions import RLPException
-from ethereum_types.numeric import U64
+from ethereum_types.numeric import U64, Uint
 
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import EthereumException, StateWithEmptyAccount
@@ -51,7 +51,15 @@ def add_block_to_chain(
             "validate_proof_of_work",
             autospec=True,
         ) as mocked_pow_validator:
-            load.fork.state_transition(chain, block)
+            if load.fork.is_aura:
+                with patch.object(
+                    fork_module,
+                    "calculate_block_difficulty",
+                    return_value=Uint((1 << 128) - 2),
+                ):
+                    load.fork.state_transition(chain, block)
+            else:
+                load.fork.state_transition(chain, block)
             mocked_pow_validator.assert_has_calls(
                 [call(block.header)],
                 any_order=False,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Fix JSON-loader support for pre-merge Gnosis AuRa fixtures while keeping json-loader `--from ConstantinopleFix`.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```