### PR TITLE
ci: schedule Hive engine and RPC compatibility tests

### DIFF
--- a/.github/workflows/hive-generic-engine.yaml
+++ b/.github/workflows/hive-generic-engine.yaml
@@ -1,0 +1,31 @@
+name: Hive - Generic - Engine
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "15 07 * * *" # Every day at 07:15 UTC
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  trigger-generic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Hive - Generic
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "hive-generic.yaml",
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                simulator: '["gnosis/engine"]',
+                concurrency_group: "engine",
+                timeout_minutes: "180"
+              }
+            });

--- a/.github/workflows/hive-generic-rpc-compat.yaml
+++ b/.github/workflows/hive-generic-rpc-compat.yaml
@@ -1,0 +1,31 @@
+name: Hive - Generic - RPC Compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "15 05 * * *" # Every day at 05:15 UTC
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  trigger-generic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Hive - Generic
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "hive-generic.yaml",
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                simulator: '["gnosis/rpc-compat"]',
+                concurrency_group: "rpc-compat",
+                timeout_minutes: "60"
+              }
+            });


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add dedicated scheduled workflows for Hive generic test suites:

- Run `gnosis/rpc-compat` daily.
- Run `gnosis/engine` daily.
- Support manual execution through `workflow_dispatch`.
- Delegate both runs to the existing `hive-generic.yaml` workflow with separate concurrency groups.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```